### PR TITLE
add support for two factor authentication with GitHub

### DIFF
--- a/hubflow-common
+++ b/hubflow-common
@@ -496,10 +496,25 @@ github_auth_token() {
     fi
 
     GITHUB_TOKEN=$(curl -s \
-      -u "$USER:$PASS" \
-      -d '{"scopes":["repo"],"note":"gitflow automation"}' \
-      "$GITHUB_API_URL/authorizations" |
-    sed -rn 's/.+"token":\s*"(.+)".+/\1/p')
+        -u "$USER:$PASS" \
+        -d '{"scopes":["repo"],"note":"gitflow automation"}' \
+      "$GITHUB_API_URL/authorizations")
+
+    if [[ $GITHUB_TOKEN == *"two-factor authentication OTP"* ]]; then
+      read -s -p "two-factor authentication code is required: " OTP
+      if [ -z "$OTP" ]; then
+        echo;
+        die "You must enter your GitHub two-factor code to authenticate with"
+      fi
+
+      GITHUB_TOKEN=$(curl -s \
+          -u "$USER:$PASS" \
+          -d '{"scopes":["repo"],"note":"gitflow automation"}' \
+          -H "X-GitHub-OTP: $OTP" \
+        "$GITHUB_API_URL/authorizations")
+    fi
+
+    GITHUB_TOKEN=$($GITHUB_TOKEN | sed -rn 's/.+"token":\s*"(.+)".+/\1/p')
 
     git config "$GITHUB_AUTH_TOKEN_KEY" "$GITHUB_TOKEN"
   fi


### PR DESCRIPTION
Added the two factor authentication flow to the github login function.

I'm not so sure about the last bit:
```
GITHUB_TOKEN=$($GITHUB_TOKEN | sed -rn 's/.+"token":\s*"(.+)".+/\1/p')
```

So you might want to check that line (wasn't sure how the `sed` & `awk` works and I'm not sure I can pass it a variable as I did)